### PR TITLE
Add includeMetadata option for timer

### DIFF
--- a/JDBCInsert.java
+++ b/JDBCInsert.java
@@ -37,7 +37,7 @@ import org.apache.camel.builder.RouteBuilder;
 public class JDBCInsert extends RouteBuilder {
     @Override
     public void configure() throws Exception {
-        from("timer://sql-insert?period=10000")
+        from("timer://sql-insert?period=10000&includeMetadata=true")
                 .setBody(simple("INSERT INTO test (data) VALUES ('message #${exchangeProperty.CamelTimerCounter}')"))
                 .to("jdbc:default")
                 .to("log:info");


### PR DESCRIPTION
Added includeMetadata=true option. This option was by default true in the previous versions of Camel.
e.g.: https://camel.apache.org/components/4.0.x/timer-component.html#_endpoint_query_option_includeMetadata
and it was changed to false in the latest 4.4 version.
https://camel.apache.org/components/4.4.x/timer-component.html#_endpoint_query_option_includeMetadata